### PR TITLE
update agenda with final program schedule

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -50,8 +50,13 @@ body {
  * Global Typography
  *------------------------------------------*/
 
-h1, h2, h3, h4, h5, h6 {
+h1, h2 {
     margin : 0 0 15px;
+    color  : #0e1555;
+    }
+
+h3, h4, h5, h6 {
+    margin : 0 0 0px;
     color  : #0e1555;
     }
 

--- a/index.html
+++ b/index.html
@@ -89,26 +89,30 @@
                 <div class="col-md-12">
                     <div class="section-title">
                         <h1>AGENDA</h1>
-                        <i>Preliminary agenda, subject to change</i>
+                        <p>The workshop will be held in
+                        <a href="https://www.google.com/maps/place/Hamilton+Hall,+Columbia+University/@40.8067381,-73.9638408,17z/data=!3m1!4b1!4m5!3m4!1s0x89c2f63e70bb34ab:0xd45652ffd4e6c310!8m2!3d40.8067381!4d-73.9616521">Hamilton Hall</a>
+                        at Columbia University.</p>
                     </div>
 
-                    <!--<div>
-                        <h2>TBD</h2>
-                        <br>
-                    </div>-->
+                    <div>
+                        <h3>Registration<h3>
+                        <h5>8:30-9:00, Hamilton Hall entrance area</h5>
+                    </div>
+
+                    <hr />
 
                     <div>
                         <h3>Welcome!</h3>
-                        <h5>8:45-9:00</h5>
-                        <h4>Speaker: Pat Pannuto</h4>
+                        <h5>9:10-9:20, Hamilton 517</h5>
+                        <h4>Speaker: <a href="https://patpannuto.com">Pat Pannuto</a></h4>
                     </div>
 
                     <hr />
 
                     <div>
                         <h3>Session 1: Who&rsquo;s There? &ndash; Finding People and Their State of Being</h3>
-                        <h5>9:00-9:45</h5>
-                        <p><i>Chair: TBA</i></p>
+                        <h5>9:20-10:20, Hamilton 517</h5>
+                        <p><i>Chair: <a href="http://florasalim.com/">Flora Salim</a></i></p>
 
                         <h4>Occupancy Sensing and Activity Recognition with Camera and Wireless Sensors</h4>
                         <p><i><small>Yang Zhao, Peter Tu (GE Research); Ming-Ching Chang (University at Albany, SUNY)</small></i><br><b>Dataset:</b> <a href="https://doi.org/10.5281/zenodo.3454785"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.3454785.svg" alt="DOI"></a></p>
@@ -125,22 +129,91 @@
 
                     <div>
                         <h3>Session 1 Breakout &amp; Discussion</h3>
-                        <h5>9:45-10:00</h5>
+                        <h5>(10:05-10:20)</h5>
                     </div>
 
                     <hr />
 
                     <div>
                         <h3>Coffee Break</h3>
-                        <h5>10:00-10:15</h5>
+                        <h5>10:20-10:45</h5>
+                    </div>
+
+                    <hr />
+
+                    <table>
+                        <tr>
+                            <td>
+                    <div>
+                        <h3>Session 2a (BuildSys Track): The Built Environment &ndash; Instrumented Buildings and Their Data</h3>
+                        <h5>10:45-12:00, Hamilton 517</h5>
+                        <p><i>Chair: <a href="https://portal.findresearcher.sdu.dk/en/persons/fsan">Fisayo Caleb Sangogboye</a></i></p>
+
+                        <h4>Dataset: An Open Dataset and Collection Tool for BMS Point Labels</h4>
+                        <p><i><small>Gabe Fierro, Sriharsha Guduguntla, David E. Culler (UC Berkeley)</small></i><br><b>Dataset:</b> <a href="https://doi.org/10.5281/zenodo.3455825"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.3455825.svg" alt="DOI"></a></p>
+
+                        <h4>Dataset: Occupancy Presence and Trajectory Dataset from an Instrumented Public
+Building</h4>
+                        <p><i><small>Anooshmita Das, Jens Hjort Schwee, Emil Stubbe Kolvig-Raun, Mikkel Baun Kjærgaard (University of Southern Denmark)</small></i><br><b>Dataset:</b> <a href="https://doi.org/10.5281/zenodo.3451537"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.3451537.svg" alt="DOI"></a></p>
+
+                        <h4>Dataset: Tracing Indoor Solar Harvesting</h4>
+                        <p><i><small>Lukas Sigrist, Andres Gomez, Lothar Thiele</small></i><br><b>Dataset:</b> <a href="https://doi.org/10.5281/zenodo.3363925"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.3363925.svg" alt="DOI"></a></p>
+                    </div>
+
+                    <div>
+                        <h3>Session 2a Breakout &amp; Discussion</h3>
+                        <h5>(11:15-11:30)</h5>
+                    </div>
+
+                    <div>
+                        <h3>BuildSys DATA Breakout &amp; Discussion</h3>
+                        <h5>(11:30-12:00)</h5>
+                    </div>
+
+                            </td>
+                            <td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td> <!-- hack, but effective -->
+                            <td>
+
+                    <div>
+                        <h3>Session 2b (SenSys Track): The Wireless Channel &ndash; More than Meets the Eye</h3>
+                        <h5>10:45-12:00, Hamilton 516</h5>
+                        <p><i>Chair: <a href="https://patpannuto.com">Pat Pannuto</a></i></p>
+
+                        <h4>Channel State Information (CSI) analysis for Predictive Maintenance using Convolutional Neural Network (CNN)</h4>
+                        <p><i><small>Prachi Bagave, Jeroen Linssen, Wouter Teeuw (Saxion, University of Applied Sciences);Jeroen Klein Brinke, Nirvana Meratnia (Pervasive Systems group at the University of Twente)</small></i><br><b>Dataset:</b> <a href="https://doi.org/10.5281/zenodo.3452876"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.3452876.svg" alt="DOI"></a></p>
+
+                        <h4>Dataset: Wireless Link Quality Estimation on FlockLab &ndash; and Beyond</h4>
+                        <p><i><small>Romain Jacob, Reto Da Forno, Roman Trueb, Andreas Biri, Lothar Thiele (ETH Zurich)</small></i><br><b>Dataset:</b> <a href="https://doi.org/10.5281/zenodo.3408382"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.3408382.svg" alt="DOI"></a></p>
+
+                        <h4>Dataset: Channel state information for different activities, participants and days</h4>
+                        <p><i><small>Jeroen Klein Brinke, Nirvana Meratnia (Pervasive Systems group at the University of Twente)</small></i></i><br><b>Dataset:</b> <a href="https://doi.org/10.4121/uuid:42bffa4c-113c-46eb-84a1-c87b6a31a99f"><img src="https://zenodo.org/badge/DOI/10.4121/uuid:42bffa4c-113c-46eb-84a1-c87b6a31a99f.svg" alt="DOI"></a></p>
+                    </div>
+
+                    <div>
+                        <h3>Session 2b Breakout &amp; Discussion</h3>
+                        <h5>(11:20-11:30)</h5>
+                    </div>
+
+                    <div>
+                        <h3>SenSys DATA Breakout &amp; Discussion</h3>
+                        <h5>(11:30-12:00)</h5>
+                    </div>
+
+                            </td></tr></table>
+
+                    <hr />
+
+                    <div>
+                        <h3>Lunch</h3>
+                        <h5>12:00-13:15</h5>
                     </div>
 
                     <hr />
 
                     <div>
-                        <h3>Session 2: The Great Outdoors &ndash; Sensing at Farm and City-Scale</h3>
-                        <h5>10:15-10:50</h5>
-                        <p><i>Chair: TBA</i></p>
+                        <h3>Session 3: The Great Outdoors &ndash; Sensing at Farm and City-Scale</h3>
+                        <h5>13:15-14:05, Hamilton 517</h5>
+                        <p><i>Chair: <a href="https://www.ucmerced.edu/content/shijia-pan">Shijia Pan</a></i></p>
 
                         <h4>Designing a Vehicle Mounted High Resolution Multi-Spectral 3D Scanner - Concept Design</h4>
                         <p><i><small>Gregory Meyers, Chengxi Zhu, Martin Mayfield, Danielle Densley Tingley, Jon Willmott, Daniel Coca (University of Sheffield)</small></i></p>
@@ -153,15 +226,15 @@
                     </div>
 
                     <div>
-                        <h3>Session 2 Breakout &amp; Discussion</h3>
-                        <h5>10:50-11:05</h5>
+                        <h3>Session 3 Breakout &amp; Discussion</h3>
+                        <h5>(13:50-14:05)</h5>
                     </div>
 
                     <hr />
 
                     <div>
-                        <h3>Session 3: Details Matter &ndash; Looking Deeply at Sensed Data</h3>
-                        <h5>11:05-11:45</h5>
+                        <h3>Session 4: Details Matter &ndash; Looking Deeply at Sensed Data</h3>
+                        <h5>14:05-15:00, Hamilton 517</h5>
                         <p><i>Chair: TBA</i></p>
 
                         <h4>A Signal Quality Assessment Metrics for Vibration-based Human Sensing Data Acquisition</h4>
@@ -177,101 +250,29 @@ Nirvana Meratnia, Paul J.M. Havinga (University of Twente)</small></i></p>
 
                     <div>
                         <h3>Session 3 Breakout &amp; Discussion</h3>
-                        <h5>11:45-12:00</h5>
+                        <h5>(14:45-15:00)</h5>
                     </div>
-
-                    <hr />
-
-                    <div>
-                        <h3>Lunch</h3>
-                        <h5>12:00-13:00</h5>
-                    </div>
-
-                    <hr />
-
-                    <table>
-                        <tr>
-                            <td>
-                    <div>
-                        <h3>Session 4a (BuildSys Track): The Built Environment &ndash; Instrumented Buildings and Their Data</h3>
-                        <h5>13:00-13:30</h5>
-                        <p><i>Chair: TBA</i></p>
-
-                        <h4>Dataset: An Open Dataset and Collection Tool for BMS Point Labels</h4>
-                        <p><i><small>Gabe Fierro, Sriharsha Guduguntla, David E. Culler (UC Berkeley)</small></i><br><b>Dataset:</b> <a href="https://doi.org/10.5281/zenodo.3455825"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.3455825.svg" alt="DOI"></a></p>
-
-                        <h4>Dataset: Occupancy Presence and Trajectory Dataset from an Instrumented Public
-Building</h4>
-                        <p><i><small>Anooshmita Das, Jens Hjort Schwee, Emil Stubbe Kolvig-Raun, Mikkel Baun Kjærgaard (University of Southern Denmark)</small></i><br><b>Dataset:</b> <a href="https://doi.org/10.5281/zenodo.3451537"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.3451537.svg" alt="DOI"></a></p>
-
-                        <h4>Dataset: Tracing Indoor Solar Harvesting</h4>
-                        <p><i><small>Lukas Sigrist, Andres Gomez, Lothar Thiele</small></i><br><b>Dataset:</b> <a href="https://doi.org/10.5281/zenodo.3363925"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.3363925.svg" alt="DOI"></a></p>
-                    </div>
-
-                    <div>
-                        <h3>Session 4a Breakout &amp; Discussion</h3>
-                        <h5>13:30-13:45</h5>
-                    </div>
-
-                    <div>
-                        <h3>BuildSys DATA Breakout &amp; Discussion</h3>
-                        <h5>13:45-14:30</h5>
-                    </div>
-
-                            </td>
-                            <td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td> <!-- hack, but effective -->
-                            <td>
-
-                    <div>
-                        <h3>Session 4b (SenSys Track): The Wireless Channel &ndash; More than Meets the Eye</h3>
-                        <h5>13:00-13:35</h5>
-                        <p><i>Chair: TBA</i></p>
-
-                        <h4>Channel State Information (CSI) analysis for Predictive Maintenance using Convolutional Neural Network (CNN)</h4>
-                        <p><i><small>Prachi Bagave, Jeroen Linssen, Wouter Teeuw (Saxion, University of Applied Sciences);Jeroen Klein Brinke, Nirvana Meratnia (Pervasive Systems group at the University of Twente)</small></i><br><b>Dataset:</b> <a href="https://doi.org/10.5281/zenodo.3452876"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.3452876.svg" alt="DOI"></a></p>
-
-                        <h4>Dataset: Wireless Link Quality Estimation on FlockLab &ndash; and Beyond</h4>
-                        <p><i><small>Romain Jacob, Reto Da Forno, Roman Trueb, Andreas Biri, Lothar Thiele (ETH Zurich)</small></i><br><b>Dataset:</b> <a href="https://doi.org/10.5281/zenodo.3408382"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.3408382.svg" alt="DOI"></a></p>
-
-                        <h4>Dataset: Channel state information for different activities, participants and days</h4>
-                        <p><i><small>Jeroen Klein Brinke, Nirvana Meratnia (Pervasive Systems group at the University of Twente)</small></i></i><br><b>Dataset:</b> <a href="https://doi.org/10.4121/uuid:42bffa4c-113c-46eb-84a1-c87b6a31a99f"><img src="https://zenodo.org/badge/DOI/10.4121/uuid:42bffa4c-113c-46eb-84a1-c87b6a31a99f.svg" alt="DOI"></a></p>
-                    </div>
-
-                    <div>
-                        <h3>Session 4b Breakout &amp; Discussion</h3>
-                        <h5>13:35-13:50</h5>
-                    </div>
-
-                    <div>
-                        <h3>SenSys DATA Breakout &amp; Discussion</h3>
-                        <h5>13:50-14:30</h5>
-                    </div>
-
-                            </td></tr></table>
 
                     <hr />
 
                     <div>
                         <h3>Coffee Break</h3>
-                        <h5>14:30-14:45</h5>
+                        <h5>15:00-15:30</h5>
                     </div>
 
                     <hr />
 
                     <div>
-                        <h3>Keynote</h3>
-                        <h5>14:45-15:45</h5>
-                        <h4>Speaker: TBA</h4>
+                        <h3>Group Discussion</h3>
+                        <h5>15:30-16:20, Hamilton 517</h5>
+                        <h4>Moderators: The DATA'19 PC (Shijia, Flora, Mikkel, and Pat)</h4>
                     </div>
 
-                    <div>
-                        <h3>Speaker Q&amp;A</h3>
-                        <h5>15:45-16:00</h5>
-                    </div>
+                    <hr />
 
                     <div>
-                        <h3>Open Discussion</h3>
-                        <h5>16:00-17:00</h5>
+                        <h3>Closing Remarks</h3>
+                        <h5>16:20-16:30, Hamilton 517</h5>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This updates the agenda to:

 - Re-order sessions slightly (SenSys/BuildSys breakouts now in the session 2 slot)
 - Align coffee breaks and lunch with the organizers timeline
 - Replace keynote with group discussion at the end
 - Add room information and chair information where available